### PR TITLE
Support fully qualified module names

### DIFF
--- a/src/etags.ts
+++ b/src/etags.ts
@@ -24,7 +24,7 @@ export class Etags {
   // Run a query by looking up key in tags.
   provideDefinition(key: string): vscode.Location[] {
     const base = path.dirname(this.file);
-    const list = this.tags.get(key);
+    const list = this.tags.get(key.replace(/^::/, ''));
     if (!list) {
       return [];
     }

--- a/src/goTo.ts
+++ b/src/goTo.ts
@@ -78,7 +78,7 @@ export class GoTo implements vscode.DefinitionProvider {
 
     return await this.guard([], async () => {
       // similar to standard Ruby wordPattern, but allow :
-      const wordPattern = /(:?[A-Za-z][^-`~@#%^&()=+[{}|;'",<>/.*\]\s\\!?]*[!?]?)/;
+      const wordPattern = /((::|)?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/;
       const query = document.getText(document.getWordRangeAtPosition(position, wordPattern));
       return await this.provideDefinition0(query);
     });

--- a/src/test/goTo.test.ts
+++ b/src/test/goTo.test.ts
@@ -56,6 +56,7 @@ describe('Go To Definition', () => {
 
     await checkDefinition(/^\s+p gub/, /^\s+def gub/);
     await checkDefinition(/^\s+p Hello::World/, /^\s+class World/);
+    await checkDefinition(/^\s+p ::Hello::World/, /^\s+class World/);
   });
 
   it('tries to rip', async () => {


### PR DESCRIPTION
Given these two lines of code:

```ruby
Hello::World
::Hello::World
```

Bust-a-gem currently only finds a symbol in the first line. This PR updates the regexes to support the latter as well.

No worries if you want to change the `wordPattern` to something else, in my tests the changes I made work fine, but there may be some edge cases I missed.